### PR TITLE
Make AudioPluginFormatManager a local variable so it goes out of scop…

### DIFF
--- a/source/CyderAudioProcessor.cpp
+++ b/source/CyderAudioProcessor.cpp
@@ -36,7 +36,6 @@ CyderAudioProcessor::CyderAudioProcessor()
      )
 #endif
 {
-    formatManager.addDefaultFormats();
 }
 
 CyderAudioProcessor::~CyderAudioProcessor()
@@ -206,10 +205,11 @@ bool CyderAudioProcessor::loadPlugin(const juce::String& pluginPath)
     // CFBundle does not like it if we attempt to load a dll outside the message thread
     jassert(juce::MessageManager::getInstance()->isThisTheMessageThread());
     
-    DBG("pluginPath: " << pluginPath);
-    
     try
     {
+        juce::AudioPluginFormatManager formatManager;
+        formatManager.addDefaultFormats();
+        
         juce::File pluginFile(pluginPath);
         const bool reloadingSamePlugin = pluginFile == currentPluginFileOriginal;
         

--- a/source/CyderAudioProcessor.hpp
+++ b/source/CyderAudioProcessor.hpp
@@ -84,8 +84,6 @@ private:
     juce::File currentPluginFileOriginal;
     juce::File currentPluginFileCopy;
     
-    juce::AudioPluginFormatManager formatManager;
-    
     std::unique_ptr<juce::AudioPluginInstance>  wrappedPlugin;
     std::unique_ptr<juce::AudioProcessorEditor> wrappedPluginEditor;
     


### PR DESCRIPTION
…e when no longer in use, hopefully allowing us to release the handle on the plugin on PC